### PR TITLE
Fixed control signals in cpb and pc submodules

### DIFF
--- a/modules/sign/compute_plain_broadcast.v
+++ b/modules/sign/compute_plain_broadcast.v
@@ -487,7 +487,7 @@ begin
         en_a <= 0;
         done_shift_gf32mul <= 0;
         alpha_en <= 0;
-        sel_b <= 0;
+        sel_b <= 1;
         o_start_add32 <= 1;
         beta_en <= 0;
     end

--- a/modules/sign/party_computation.v
+++ b/modules/sign/party_computation.v
@@ -453,7 +453,7 @@ begin
     if (i_start) begin
         b_reg <= i_b;
     end
-    else if (shift_a_reg) begin
+    else if (shift_b_reg) begin
         b_reg <= {b_reg[32*T-32-1:0], b_reg[32*T-1:32*T-32]};
     end
 end
@@ -1038,7 +1038,7 @@ begin
         en_a <= 0;
         done_shift_gf32mul <= 0;
         alpha_en <= 0;
-        sel_b <= 0;
+        sel_b <= 1;
         o_start_add32 <= 1;
         beta_en <= 0;
         en_pr <= 0;
@@ -1147,7 +1147,7 @@ begin
 
     s_start_f_eval: begin
         sel_r_eps <= 0;
-        sel_qs <= 2;
+        sel_qs <= 3;
         o_start_evaluate <= 1;
         ab_en <= 0;
         o_start_mul32 <= 0;
@@ -1173,7 +1173,7 @@ begin
 
     s_done_f_eval: begin
         sel_r_eps <= 0;
-        sel_qs <= 2;
+        sel_qs <= 3;
         o_start_evaluate <= 0;
         ab_en <= 0;
         o_start_mul32 <= 0;

--- a/modules/sign/sign/compute_plain_broadcast.v
+++ b/modules/sign/sign/compute_plain_broadcast.v
@@ -481,7 +481,7 @@ begin
         en_a <= 0;
         done_shift_gf32mul <= 0;
         alpha_en <= 0;
-        sel_b <= 0;
+        sel_b <= 1;
         o_start_add32 <= 1;
         beta_en <= 0;
     end

--- a/modules/sign/sign/party_computation.v
+++ b/modules/sign/sign/party_computation.v
@@ -452,7 +452,7 @@ begin
     if (i_start) begin
         b_reg <= i_b;
     end
-    else if (shift_a_reg) begin
+    else if (shift_b_reg) begin
         b_reg <= {b_reg[32*T-32-1:0], b_reg[32*T-1:32*T-32]};
     end
 end
@@ -1039,7 +1039,7 @@ begin
         alpha_en <= 0;
         sel_b <= 0;
         o_start_add32 <= 1;
-        beta_en <= 0;
+        beta_en <= 1;
         en_pr <= 0;
         shift_pf <= 0;
         en_fr <= 0;
@@ -1146,7 +1146,7 @@ begin
 
     s_start_f_eval: begin
         sel_r_eps <= 0;
-        sel_qs <= 2;
+        sel_qs <= 3;
         o_start_evaluate <= 1;
         ab_en <= 0;
         o_start_mul32 <= 0;
@@ -1172,7 +1172,7 @@ begin
 
     s_done_f_eval: begin
         sel_r_eps <= 0;
-        sel_qs <= 2;
+        sel_qs <= 3;
         o_start_evaluate <= 0;
         ab_en <= 0;
         o_start_mul32 <= 0;


### PR DESCRIPTION
Fixed control signals in compute_plain_broadcast and party_computation submodules to match the signature scheme specification.